### PR TITLE
feat: 🎸 add warning when using constants in fabricators

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,20 @@ import { Fabricator, Fabricate } from '@travelperksl/fabricator'
 
 Fabricator('user', {
   id: () => Fabricate.sequence('userId'),
-  name: () => faker.name.firstName() + faker.name.lastName()
-  admin: false
+  name: () => faker.name.firstName() + faker.name.lastName(),
+  admin: () => false,
 })
 ```
 
 You simply pass a name for the model and its definition. The definition is an
-object where each key can be a value or a function. If you need dynamic data you
-can use `Fabricate.sequence()` or use a library like
+object where each key is a function. If you need dynamic data you can use
+`Fabricate.sequence()` or use a library like
 [faker](https://www.npmjs.com/package/faker).
 
 You can also extend existing models. For example:
 
 ```js
-Fabricator.extend('user', 'admin', { admin: true })
+Fabricator.extend('user', 'admin', { admin: () => true })
 ```
 
 In this case, `admin` will inherit all the properties from `user` but will
@@ -52,7 +52,7 @@ const admin = Fabricate('admin')
 You can overwrite some values by passing a model definition as second parameter:
 
 ```js
-const blockedUser = Fabricate('user', { isBlocked: true })
+const blockedUser = Fabricate('user', { isBlocked: () => true })
 // => { id: 3, name: 'Donald Brown', admin: false, isBlocked: true }
 ```
 
@@ -65,7 +65,7 @@ If you need to quickly generate more than one object you can use
 const people = Fabricate.times(2, 'user')
 // => [{ id: 3, ... }, { id: 4, ... }]
 
-const colleagues = Fabricate.times(2, 'user', { companyId: 5 })
+const colleagues = Fabricate.times(2, 'user', { companyId: () => 5 })
 // => [{ id: 5, companyId: 5 }, { id: 6, companyId: 6 }]
 ```
 

--- a/__tests__/Fabricate.js
+++ b/__tests__/Fabricate.js
@@ -14,10 +14,10 @@ describe('Fabricate()', () => {
     expect(Fabricate('empty-object')).toEqual({})
 
     Fabricator('hardcoded-values', {
-      boolean: true,
-      number: 1,
-      string: 'a',
-      array: [0],
+      boolean: () => true,
+      number: () => 1,
+      string: () => 'a',
+      array: () => [0],
     })
     expect(Fabricate('hardcoded-values')).toEqual({
       boolean: true,
@@ -34,7 +34,7 @@ describe('Fabricate()', () => {
   })
 
   it('should return an object based on the model and on the variations', () => {
-    Fabricator('user', { id: 1, admin: false })
+    Fabricator('user', { id: () => 1, admin: () => false })
     expect(Fabricate('user', { admin: true })).toEqual({ id: 1, admin: true })
   })
 
@@ -48,7 +48,7 @@ describe('Fabricate()', () => {
   describe('Fabricate.times()', () => {
     it('should create an array based on the model', () => {
       const modelName = 'user'
-      const model = { id: 1 }
+      const model = { id: () => 1 }
       Fabricator(modelName, model)
       const times = 3
       const objs = Fabricate.times(3, modelName)
@@ -58,10 +58,10 @@ describe('Fabricate()', () => {
 
     it('should create an array based on the model and variations', () => {
       const modelName = 'user'
-      const model = { id: 1, admin: false }
+      const model = { id: () => 1, admin: () => false }
       Fabricator(modelName, model)
       const times = 3
-      const objs = Fabricate.times(3, modelName, { admin: true })
+      const objs = Fabricate.times(3, modelName, { admin: () => true })
       expect(objs.length).toBe(times)
       objs.forEach(obj => expect(obj).toEqual({ id: 1, admin: true }))
     })

--- a/__tests__/Fabricator.js
+++ b/__tests__/Fabricator.js
@@ -18,11 +18,26 @@ describe('Fabricator()', () => {
 
   it('should store a model with a definition', () => {
     const modelName = 'user'
-    const model = { id: 1, firstName: () => 'John', lastName: () => 'Doe' }
+    const model = {
+      id: () => 1,
+      firstName: () => 'John',
+      lastName: () => 'Doe',
+    }
     Fabricator(modelName, model)
     const modelNames = Object.keys(models)
     expect(modelNames).toContain(modelName)
     expect(models[modelName]).toEqual(model)
+  })
+
+  it('should warn when registering a model with a constant', () => {
+    const model = { id: 'constant' }
+    const spy = jest.spyOn(console, 'warn').mockImplementationOnce(() => {})
+    Fabricator('user', model)
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith(
+      'Defining a fabricator using a constant is going to be deprecated in the next version. Please use a function instead. Check user.id.'
+    )
+    spy.mockRestore()
   })
 
   it('should throw an error when registering an existing model', () => {
@@ -37,7 +52,7 @@ describe('Fabricator()', () => {
     it('should create an alias for a model', () => {
       const baseModelName = 'user'
       const baseModel = {
-        id: 1,
+        id: () => 1,
         firstName: () => 'John',
         lastName: () => 'Doe',
       }
@@ -56,15 +71,15 @@ describe('Fabricator()', () => {
     it('should create a model starting from an existing one', () => {
       const baseModelName = 'user'
       const baseModel = {
-        id: 1,
+        id: () => 1,
         firstName: () => 'John',
         lastName: () => 'Doe',
-        admin: false,
+        admin: () => false,
       }
       Fabricator(baseModelName, baseModel)
 
       const modelName = 'admin'
-      const model = { admin: true }
+      const model = { admin: () => true }
       Fabricator.extend(baseModelName, modelName, model)
 
       const modelNames = Object.keys(models)

--- a/package.json
+++ b/package.json
@@ -39,8 +39,12 @@
   },
   "lint-staged": {
     "linters": {
-      "*.{js,json,md}": [
+      "*.{js,json}": [
         "prettier --write",
+        "git add"
+      ],
+      "*.md": [
+        "prettier --write --parser markdown",
         "git add"
       ]
     },

--- a/src/fabricator.js
+++ b/src/fabricator.js
@@ -4,6 +4,14 @@ function Fabricator(name, model = {}) {
   if (models[name]) {
     throw new Error(`Model "${name}" has already been registered`)
   }
+  Object.keys(model).forEach(key => {
+    if (typeof model[key] !== 'function') {
+      console.warn(
+        `Defining a fabricator using a constant is going to be deprecated in the next version. Please use a function instead. Check ${name}.${key}.`
+      )
+    }
+  })
+
   models[name] = model
 }
 


### PR DESCRIPTION
Defining fabricator properties using constants is going to be deprecated
in the next major release. This commit adds a warning to allow users to
easily upgrade their fabricators.