### PR TITLE
fix: 🐛 sequence starts from 1 instead of 0

### DIFF
--- a/__tests__/sequence.js
+++ b/__tests__/sequence.js
@@ -2,14 +2,14 @@ import { Fabricator, sequence } from '../src/fabricator'
 
 describe('sequence()', () => {
   it('should return an increasing number every time it gets called', () => {
-    for (let i = 0; i < 20; i++) {
+    for (let i = 1; i <= 20; i++) {
       expect(sequence()).toBe(i)
     }
   })
 
   it('should increase the sequences separately', () => {
     const names = ['foo', 'bar', 'baz']
-    for (let i = 0; i < 20; i++) {
+    for (let i = 1; i <= 20; i++) {
       names.forEach(name => expect(sequence(name)).toBe(i))
     }
   })
@@ -20,23 +20,23 @@ describe('sequence.reset()', () => {
 
   it('should reset all sequences when called with no arguments', () => {
     const names = ['foo', 'bar', 'baz']
-    for (let i = 0; i < 20; i++) {
+    for (let i = 1; i <= 20; i++) {
       names.forEach(name => sequence(name))
     }
     sequence.reset()
-    for (let i = 0; i < 20; i++) {
+    for (let i = 1; i <= 20; i++) {
       names.forEach(name => expect(sequence(name)).toBe(i))
     }
   })
 
   it('should reset the sequence selected by name', () => {
     const names = ['foo', 'bar', 'baz']
-    for (let i = 0; i < 20; i++) {
+    for (let i = 1; i <= 20; i++) {
       names.forEach(name => sequence(name))
       sequence('extra')
     }
     sequence.reset('extra')
-    for (let i = 0; i < 20; i++) {
+    for (let i = 1; i <= 20; i++) {
       names.forEach(name => expect(sequence(name)).toBe(i + 20))
       expect(sequence('extra')).toBe(i)
     }

--- a/src/fabricator.js
+++ b/src/fabricator.js
@@ -32,7 +32,7 @@ const sequence = (
   name = '__VOID_SEQUENCE_NAME_DO_NOT_USE_OR_YOU_WILL_BE_FIRED'
 ) => {
   if (sequences[name] == null) {
-    sequences[name] = -1
+    sequences[name] = 0
   }
   return ++sequences[name]
 }


### PR DESCRIPTION
Since sequence is trying to simulate a DB id we align to what most DBs
do by starting the sequence from 1 instead of 0

BREAKING CHANGE: 🧨 sequence starts from 1 instead of 0