### PR TITLE
Eliminate NPM token

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,28 +52,6 @@ jobs:
             - 'coverage'
             - 'junit.xml'
 
-  publish_package:
-    <<: *defaults
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - run:
-          name: Build Package with Babel
-          command: npm run build
-      - run:
-          name: Extract types
-          command: npm run extract-types
-      - run:
-          name: Store NPM registry credentials
-          command: |
-            echo email=core-web@travelperk.com >> ./.npmrc
-            echo always-auth=true >> ./.npmrc
-            echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ./.npmrc
-      - run:
-          name: Publish package
-          command: npm publish
-
 workflows:
   main:
     jobs:
@@ -84,13 +62,3 @@ workflows:
       - test_jest:
           requires:
             - install
-      - publish_package:
-          # Access to push to npmjs
-          context: [npmjs]
-          requires:
-            - check
-            - test_jest
-          filters:
-            branches:
-              only:
-                - main


### PR DESCRIPTION
[APP-79589](https://travelperk.atlassian.net/browse/APP-79589)

We have eliminated the never expiring tokens from NPM. Now, in order to publish to NPMJS we need to produce a temporary token.
Since this is the only repository that we have in NPM and we change it once every _n_ years, I propose to do the process manually when needed and eliminate the automatic publishing of the repository. Impact over effort.

[APP-79589]: https://travelperk.atlassian.net/browse/APP-79589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ